### PR TITLE
save voting table 

### DIFF
--- a/server/models/parsers/client-to-server-parsers/extract-voting-registrations.js
+++ b/server/models/parsers/client-to-server-parsers/extract-voting-registrations.js
@@ -4,7 +4,19 @@ const voterChoiceConverter  = require('../voter-choice');
 
 function extractVotingRegistrations(data) {
 
-  if(data.voting.citizenStatus === '' || data.voting.eligibilityRequirements === '' || data.voting.optOut === '') { return null; }
+  if(data.voting.citizenStatus === '' || data.voting.eligibilityRequirements === '' || data.voting.optOut === '') {
+    return {
+      application_id:   data.id,
+      is_citizen:       data.voting.citizenStatus,
+      is_eligible:      data.voting.eligibilityRequirements,
+      type:             '',
+      opted_out:        '',
+      party:            '',
+      language:         data.voting.ballotLanguage,
+      vote_by_mail:     '',
+      should_contact:   ''
+    };
+  }
   const voterChoice = voterChoiceConverter.clientToDBMapping(data.voting.optOut);
   return {
     application_id:     data.id,

--- a/test/server/models/parsers/client-to-server-parser-tests/extract-voting-registrations-test.js
+++ b/test/server/models/parsers/client-to-server-parser-tests/extract-voting-registrations-test.js
@@ -1,0 +1,33 @@
+'use strict';
+const assert          = require('assert');
+const extractVoting   = require('../../../../../server/models/parsers/client-to-server-parsers/extract-voting-registrations');
+
+describe('extracting voting registration', function() {
+  let data;
+
+  beforeEach(function() {
+    data = {
+      id: '11342',
+      voting: {
+        ballotLanguage: '',
+        citizenStatus: 'Yes',
+        eligibilityRequirements: 'decline',
+        optOut: '',
+        politicalPartyChoose: '',
+        contactMethods: {
+          shouldContact: ''
+        }
+      }
+    };
+  });
+
+
+  it('returns an object with is_citizen and is_eligible equal to null if user has not answered opted_out question', function() {
+    let table = extractVoting(data);
+    assert.equal(table.application_id, data.id);
+    assert.equal(table.is_citizen, 'Yes');
+    assert.equal(table.is_eligible, 'decline');
+    assert.equal(table.opted_out, '');
+  });
+
+});


### PR DESCRIPTION
**** don't merge until we get new alice server environments and we can test builds more easily ****

Phoebe expects to get a value for voting table columns for every application, but we had a condition on the extract-voting-registrations parser that would return null if the opt_out value is blank. So in the cases where the user declines to answer the citizenship question, Phoebe gets no result and the technician has to select "decline" for the user.

This change makes it so that instead of returning null, the citizenship and eligibility answers will be saved to the db even if the user has declined to answer one of them.